### PR TITLE
Add Wii U gamepad battery sensor and improve async operations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
         - name: "Set up Python"
           uses: actions/setup-python@v5.2.0
           with:
-            python-version: "3.12"
+            python-version: "3.13"
             cache: "pip"
 
         - name: "Install requirements"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
       - name: "ZIP the integration directory"
         shell: "bash"
         run: |
-          cd "${{ github.workspace }}/custom_components/integration_blueprint"
-          zip integration_blueprint.zip -r ./
+          cd "${{ github.workspace }}/custom_components/nintendo_wiiu_ristretto"
+          zip nintendo_wiiu_ristretto.zip -r ./
 
       - name: "Upload the ZIP file to the release"
         uses: "softprops/action-gh-release@v2.0.8"
         with:
-          files: ${{ github.workspace }}/custom_components/integration_blueprint/integration_blueprint.zip
+          files: ${{ github.workspace }}/custom_components/nintendo_wiiu_ristretto/nintendo_wiiu_ristretto.zip

--- a/custom_components/nintendo_wiiu_ristretto/__init__.py
+++ b/custom_components/nintendo_wiiu_ristretto/__init__.py
@@ -11,10 +11,7 @@ PLATFORMS = [Platform.BUTTON, Platform.MEDIA_PLAYER, Platform.SENSOR]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Entry setup."""
-    coordinator = WiiUCoordinator(
-        hass=hass,
-        config_entry=entry
-    )
+    coordinator = WiiUCoordinator(hass=hass, config_entry=entry)
 
     entry.runtime_data = coordinator
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/nintendo_wiiu_ristretto/__init__.py
+++ b/custom_components/nintendo_wiiu_ristretto/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant
 
 from .coordinator import WiiUCoordinator
 
-PLATFORMS = [Platform.BUTTON, Platform.MEDIA_PLAYER]
+PLATFORMS = [Platform.BUTTON, Platform.MEDIA_PLAYER, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/nintendo_wiiu_ristretto/__init__.py
+++ b/custom_components/nintendo_wiiu_ristretto/__init__.py
@@ -5,7 +5,6 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from .coordinator import WiiUCoordinator
-from .const import DOMAIN
 
 PLATFORMS = [Platform.BUTTON, Platform.MEDIA_PLAYER]
 

--- a/custom_components/nintendo_wiiu_ristretto/__init__.py
+++ b/custom_components/nintendo_wiiu_ristretto/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant
 
 from .coordinator import WiiUCoordinator
 
-PLATFORMS = [Platform.BUTTON, Platform.MEDIA_PLAYER, Platform.SENSOR]
+PLATFORMS = [Platform.BUTTON, Platform.MEDIA_PLAYER, Platform.SENSOR, Platform.BINARY_SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/nintendo_wiiu_ristretto/binary_sensor.py
+++ b/custom_components/nintendo_wiiu_ristretto/binary_sensor.py
@@ -1,0 +1,55 @@
+"""Binary sensor components for Ristretto."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+
+from .coordinator import WiiUCoordinator
+from .entity import WiiUEntity
+
+
+@dataclass(frozen=True, kw_only=True)
+class WiiUBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Class describing Wii U binary sensor entities."""
+
+    is_on_fn: Callable[[WiiUEntity], None] = lambda: None
+
+ENTITY_DESCRIPTIONS = [
+    WiiUBinarySensorEntityDescription(
+        key="gamepad_charging",
+        device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
+        name="Gamepad Charging",
+        is_on_fn=lambda entity: entity.coordinator.gamepad_battery == 0
+    )
+]
+
+async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
+    """Set up the button platform."""
+    coordinator = config_entry.runtime_data
+    if not isinstance(coordinator, WiiUCoordinator):
+        return
+    async_add_entities(
+        [
+            GenericWiiUBinarySensor(coordinator=coordinator, description=description)
+            for description in ENTITY_DESCRIPTIONS
+        ]
+    )
+
+class GenericWiiUBinarySensor(WiiUEntity, BinarySensorEntity):
+    """A generic Wii U binary sensor."""
+
+    def __init__(self, coordinator: WiiUCoordinator, description: WiiUBinarySensorEntityDescription):
+        """Initialize a binary sensor."""
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+        self.entity_description: WiiUBinarySensorEntityDescription = description
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the binary sensor is on."""
+        return self.entity_description.is_on_fn(self)

--- a/custom_components/nintendo_wiiu_ristretto/binary_sensor.py
+++ b/custom_components/nintendo_wiiu_ristretto/binary_sensor.py
@@ -24,7 +24,7 @@ ENTITY_DESCRIPTIONS = [
         key="gamepad_charging",
         device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
         name="Gamepad Charging",
-        is_on_fn=lambda entity: entity.coordinator.gamepad_battery == 0
+        is_on_fn=lambda entity: entity.coordinator.gamepad_charging
     )
 ]
 

--- a/custom_components/nintendo_wiiu_ristretto/button.py
+++ b/custom_components/nintendo_wiiu_ristretto/button.py
@@ -35,6 +35,12 @@ ENTITY_DESCRIPTIONS: list[WiiUButtonEntityDescription] = [
         icon="mdi:restart",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    WiiUButtonEntityDescription(
+        key="launch_vwii",
+        name="Launch vWii",
+        press_fn=lambda entity: entity.coordinator.wii.async_launch_vwii_menu,
+        icon="mdi:nintendo-wii"
+    )
 ]
 
 

--- a/custom_components/nintendo_wiiu_ristretto/button.py
+++ b/custom_components/nintendo_wiiu_ristretto/button.py
@@ -18,6 +18,11 @@ from .entity import WiiUEntity
 class WiiUButtonEntityDescription(ButtonEntityDescription):
     """Class describing Wii U button entities."""
 
+    key: str
+    name: str
+    device_class: ButtonDeviceClass | None = None
+    icon: str | None = None
+    entity_category: EntityCategory | None = None
     press_fn: Callable[[WiiUEntity], None] = lambda: None
 
 
@@ -26,7 +31,7 @@ ENTITY_DESCRIPTIONS: list[WiiUButtonEntityDescription] = [
         key="restart",
         name="Restart",
         device_class=ButtonDeviceClass.RESTART,
-        press_fn=lambda entity: entity.coordinator.async_reboot(),
+        press_fn=lambda entity: entity.coordinator.wii.async_reboot,
         icon="mdi:restart",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),

--- a/custom_components/nintendo_wiiu_ristretto/button.py
+++ b/custom_components/nintendo_wiiu_ristretto/button.py
@@ -43,10 +43,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
     coordinator = config_entry.runtime_data
     if not isinstance(coordinator, WiiUCoordinator):
         return
-    for description in ENTITY_DESCRIPTIONS:
-        async_add_entities(
-            [GenericWiiUButton(coordinator=coordinator, description=description)]
-        )
+    async_add_entities(
+        [GenericWiiUButton(coordinator=coordinator, description=description)
+         for description in ENTITY_DESCRIPTIONS]
+    )
 
 
 class GenericWiiUButton(WiiUEntity, ButtonEntity):
@@ -59,6 +59,11 @@ class GenericWiiUButton(WiiUEntity, ButtonEntity):
         super().__init__(coordinator=coordinator)
         self.coordinator = coordinator
         self.entity_description: WiiUButtonEntityDescription = description
+
+    @property
+    def available(self) -> bool:
+        """Return availablity for the entity."""
+        return self.coordinator.is_on
 
     async def async_press(self) -> None:
         """Perform a given action on press."""

--- a/custom_components/nintendo_wiiu_ristretto/button.py
+++ b/custom_components/nintendo_wiiu_ristretto/button.py
@@ -44,8 +44,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
     if not isinstance(coordinator, WiiUCoordinator):
         return
     async_add_entities(
-        [GenericWiiUButton(coordinator=coordinator, description=description)
-         for description in ENTITY_DESCRIPTIONS]
+        [
+            GenericWiiUButton(coordinator=coordinator, description=description)
+            for description in ENTITY_DESCRIPTIONS
+        ]
     )
 
 

--- a/custom_components/nintendo_wiiu_ristretto/button.py
+++ b/custom_components/nintendo_wiiu_ristretto/button.py
@@ -69,4 +69,4 @@ class GenericWiiUButton(WiiUEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Perform a given action on press."""
-        await self.entity_description.press_fn(self)
+        await self.entity_description.press_fn(self)()

--- a/custom_components/nintendo_wiiu_ristretto/config_flow.py
+++ b/custom_components/nintendo_wiiu_ristretto/config_flow.py
@@ -3,11 +3,16 @@
 from typing import Any
 
 import voluptuous as vol
-
-from homeassistant.const import CONF_IP_ADDRESS, CONF_PORT, CONF_NAME, CONF_SCAN_INTERVAL
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import (
+    CONF_IP_ADDRESS,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_SCAN_INTERVAL,
+    CONF_TIMEOUT,
+)
 
-from .const import DOMAIN
+from .const import DEFAULT_TIMEOUT, DOMAIN
 
 SCHEMA = vol.Schema(
     {
@@ -15,6 +20,7 @@ SCHEMA = vol.Schema(
         vol.Required(CONF_PORT, default=8572): int,
         vol.Optional(CONF_NAME, default="Wii U"): str,
         vol.Optional(CONF_SCAN_INTERVAL, default=10): int,
+        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): int
     }
 )
 

--- a/custom_components/nintendo_wiiu_ristretto/config_flow.py
+++ b/custom_components/nintendo_wiiu_ristretto/config_flow.py
@@ -20,9 +20,10 @@ SCHEMA = vol.Schema(
         vol.Required(CONF_PORT, default=8572): int,
         vol.Optional(CONF_NAME, default="Wii U"): str,
         vol.Optional(CONF_SCAN_INTERVAL, default=10): int,
-        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): int
+        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): int,
     }
 )
+
 
 class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle flow."""

--- a/custom_components/nintendo_wiiu_ristretto/const.py
+++ b/custom_components/nintendo_wiiu_ristretto/const.py
@@ -1,3 +1,5 @@
 """Nintendo WiiU Ristretto constants."""
 
 DOMAIN = "nintendo_wiiu_ristretto"
+DEFAULT_TIMEOUT = 10
+DEFAULT_UPDATE_INTERVAL = 10

--- a/custom_components/nintendo_wiiu_ristretto/coordinator.py
+++ b/custom_components/nintendo_wiiu_ristretto/coordinator.py
@@ -2,9 +2,9 @@
 
 import json
 import logging
+from asyncio import TimeoutError
 from datetime import timedelta
 
-from asyncio import TimeoutError
 from aiohttp import ClientOSError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -44,7 +44,9 @@ class WiiUCoordinator(DataUpdateCoordinator):
             name="Wii U Coordinator",
             config_entry=config_entry,
             update_interval=timedelta(
-                seconds=config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+                seconds=config_entry.data.get(
+                    CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL
+                )
             ),
             always_update=True,
         )
@@ -75,7 +77,7 @@ class WiiUCoordinator(DataUpdateCoordinator):
             ip_address=self._ip_address,
             ristretto_port=self._ristretto_port,
             session=async_create_clientsession(self.hass),
-            timeout=self.config_entry.data.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
+            timeout=self.config_entry.data.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
         )
         self.wii.timeout = self.config_entry.data.get(CONF_SCAN_INTERVAL)
         await self.async_get_hardware_information()

--- a/custom_components/nintendo_wiiu_ristretto/coordinator.py
+++ b/custom_components/nintendo_wiiu_ristretto/coordinator.py
@@ -79,7 +79,6 @@ class WiiUCoordinator(DataUpdateCoordinator):
             session=async_create_clientsession(self.hass),
             timeout=self.config_entry.data.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
         )
-        self.wii.timeout = self.config_entry.data.get(CONF_SCAN_INTERVAL)
         await self.async_get_hardware_information()
         await self._get_source_list()
 
@@ -90,7 +89,9 @@ class WiiUCoordinator(DataUpdateCoordinator):
             await self._get_source_list()
             self.gamepad_battery = await self.wii.async_get_gamepad_battery()
             self.is_on = True
-        except (TimeoutError, ClientOSError, ConnectionError):
+        except ClientOSError:
+            pass # silently discard connection reset errors as this can happen when switching source
+        except (TimeoutError, ConnectionError):
             self.is_on = False
         except Exception as e:
             _LOGGER.exception("Error updating data", exc_info=e)

--- a/custom_components/nintendo_wiiu_ristretto/coordinator.py
+++ b/custom_components/nintendo_wiiu_ristretto/coordinator.py
@@ -5,10 +5,18 @@ import logging
 from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_IP_ADDRESS, CONF_PORT, CONF_SCAN_INTERVAL
+from homeassistant.const import (
+    CONF_IP_ADDRESS,
+    CONF_PORT,
+    CONF_SCAN_INTERVAL,
+    CONF_TIMEOUT,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from python_wiiu_ristretto import WiiU
+
+from .const import DEFAULT_TIMEOUT, DEFAULT_UPDATE_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,7 +41,7 @@ class WiiUCoordinator(DataUpdateCoordinator):
             name="Wii U Coordinator",
             config_entry=config_entry,
             update_interval=timedelta(
-                seconds=config_entry.data.get(CONF_SCAN_INTERVAL, 10)
+                seconds=config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL)
             ),
             always_update=True,
         )
@@ -44,51 +52,37 @@ class WiiUCoordinator(DataUpdateCoordinator):
 
     async def async_get_hardware_information(self) -> None:
         """Get hardware information."""
-        self.serial = await self.hass.async_add_executor_job(
-            self.wii.get_device_serial_id
-        )
-        self.hw_version = await self.hass.async_add_executor_job(
-            self.wii.get_device_hardware_version
-        )
-        self.model = await self.hass.async_add_executor_job(
-            self.wii.get_device_model_number
-        )
-        self.sw_version = await self.hass.async_add_executor_job(
-            self.wii.get_device_version
-        )
+        self.serial = await self.wii.async_get_device_serial_id()
+        self.hw_version = await self.wii.async_get_device_hardware_version()
+        self.model = await self.wii.async_get_device_model_number()
+        self.sw_version = await self.wii.async_get_device_version()
 
-    def _get_current_app_name(self) -> None:
+    async def _get_current_app_name(self) -> None:
         """Get the current app name."""
-        self.source = self.wii.get_current_title_name()
+        self.source = await self.wii.async_get_current_title_name()
 
-    def _get_source_list(self) -> None:
+    async def _get_source_list(self) -> None:
         """Get the source list."""
-        self.title_map = json.loads(self.wii.get_title_list())
-        self.source_list = []
-        for value in self.title_map.values():
-            self.source_list.append(value)
+        self.title_map = json.loads(await self.wii.async_get_title_list())
+        self.source_list = list(self.title_map.values())
 
-    def _launch_title(self, source: int) -> None:
-        """Launch a given title on the Wii U."""
-        self.wii.launch_title(source)
-
-    async def _async_setup(self):
+    async def _async_setup(self) -> None:
         """Set up the Wii U connection."""
         self.wii = WiiU(
-            ip_address=self._ip_address, ristretto_port=self._ristretto_port
+            ip_address=self._ip_address,
+            ristretto_port=self._ristretto_port,
+            session=async_create_clientsession(self.hass),
+            timeout=self.config_entry.data.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
         )
         self.wii.timeout = self.config_entry.data.get(CONF_SCAN_INTERVAL)
         await self.async_get_hardware_information()
-        await self.hass.async_add_executor_job(self._get_source_list)
+        await self._get_source_list()
 
-    async def _async_update_data(self):
+    async def _async_update_data(self) -> None:
         """Update the data from the Wii U."""
         try:
-            await self.hass.async_add_executor_job(self._get_current_app_name)
-            await self.hass.async_add_executor_job(self._get_source_list)
+            await self._get_current_app_name()
+            await self._get_source_list()
             self.is_on = True
         except Exception as e:
             self.is_on = False
-
-    async def async_reboot(self) -> None:
-        await self.hass.async_add_executor_job(self.wii.reboot)

--- a/custom_components/nintendo_wiiu_ristretto/coordinator.py
+++ b/custom_components/nintendo_wiiu_ristretto/coordinator.py
@@ -26,6 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 class WiiUCoordinator(DataUpdateCoordinator):
     """Coordinate communication with Wii U."""
 
+    gamepad_charging: bool = False
     gamepad_battery: int = None
     serial: str = None
     source_list: list = None
@@ -90,9 +91,11 @@ class WiiUCoordinator(DataUpdateCoordinator):
             if isinstance(self.gamepad_battery, int):
                 if self.gamepad_battery == 0:
                     # battery charging
+                    self.gamepad_charging = True
                     self.gamepad_battery = 100
                 else:
-                    self.gamepad_battery = (self.gamepad_battery/5)*100
+                    self.gamepad_charging = False
+                    self.gamepad_battery = ((self.gamepad_battery-1)/5)*100
             self.is_on = True
         except ClientOSError:
             pass # silently discard connection reset errors as this can happen when switching source

--- a/custom_components/nintendo_wiiu_ristretto/coordinator.py
+++ b/custom_components/nintendo_wiiu_ristretto/coordinator.py
@@ -88,6 +88,8 @@ class WiiUCoordinator(DataUpdateCoordinator):
             await self._get_current_app_name()
             await self._get_source_list()
             self.gamepad_battery = await self.wii.async_get_gamepad_battery()
+            if isinstance(self.gamepad_battery, int):
+                self.gamepad_battery = (self.gamepad_battery/6)*100
             self.is_on = True
         except ClientOSError:
             pass # silently discard connection reset errors as this can happen when switching source

--- a/custom_components/nintendo_wiiu_ristretto/coordinator.py
+++ b/custom_components/nintendo_wiiu_ristretto/coordinator.py
@@ -86,7 +86,6 @@ class WiiUCoordinator(DataUpdateCoordinator):
         """Update the data from the Wii U."""
         try:
             await self._get_current_app_name()
-            await self._get_source_list()
             self.gamepad_battery = await self.wii.async_get_gamepad_battery()
             if isinstance(self.gamepad_battery, int):
                 self.gamepad_battery = (self.gamepad_battery/6)*100

--- a/custom_components/nintendo_wiiu_ristretto/entity.py
+++ b/custom_components/nintendo_wiiu_ristretto/entity.py
@@ -13,7 +13,13 @@ class WiiUEntity(CoordinatorEntity[WiiUCoordinator]):
     def __init__(self, coordinator: WiiUCoordinator) -> None:
         """Initialize entity and coordinator."""
         super().__init__(coordinator=coordinator)
-        self._attr_unique_id = coordinator.config_entry.entry_id
+
+    @property
+    def unique_id(self) -> str:
+        """Generate a unique ID for this entity."""
+        if self.entity_description is not None:
+            return f"{self.coordinator.serial}_{self.entity_description.key}"
+        return f"{self.coordinator.serial}_{self.name}"
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/nintendo_wiiu_ristretto/media_player.py
+++ b/custom_components/nintendo_wiiu_ristretto/media_player.py
@@ -71,11 +71,10 @@ class NintendoWiiUMediaPlayer(WiiUEntity, MediaPlayerEntity):
         """Select a source on the Wii U console."""
         for titleid, name in self.coordinator.title_map.items():
             if name == source:
-                return await self.hass.async_add_executor_job(
-                    self.coordinator.wii.launch_title, titleid
-                )
+                return await self.coordinator.wii.async_launch_title(titleid)
         return None
 
     async def async_turn_off(self) -> None:
         """Turn off the Wii U console."""
-        await self.hass.async_add_executor_job(self.coordinator.wii.shutdown)
+        await self.coordinator.wii.async_shutdown()
+        self.coordinator.is_on = False

--- a/custom_components/nintendo_wiiu_ristretto/media_player.py
+++ b/custom_components/nintendo_wiiu_ristretto/media_player.py
@@ -71,8 +71,9 @@ class NintendoWiiUMediaPlayer(WiiUEntity, MediaPlayerEntity):
         """Select a source on the Wii U console."""
         for titleid, name in self.coordinator.title_map.items():
             if name == source:
-                return await self.coordinator.wii.async_launch_title(titleid)
-        return None
+                await self.coordinator.wii.async_launch_title(titleid)
+                self.coordinator.source = name
+                self.schedule_update_ha_state(force_refresh=True)
 
     async def async_turn_off(self) -> None:
         """Turn off the Wii U console."""

--- a/custom_components/nintendo_wiiu_ristretto/media_player.py
+++ b/custom_components/nintendo_wiiu_ristretto/media_player.py
@@ -51,6 +51,11 @@ class NintendoWiiUMediaPlayer(WiiUEntity, MediaPlayerEntity):
         self._attr_source_list = coordinator.source_list
 
     @property
+    def unique_id(self) -> str:
+        """Unique ID for media player."""
+        return self.coordinator.serial
+
+    @property
     def app_name(self) -> str:
         """Return the name of the currently running app."""
         return self.coordinator.source

--- a/custom_components/nintendo_wiiu_ristretto/media_player.py
+++ b/custom_components/nintendo_wiiu_ristretto/media_player.py
@@ -78,3 +78,4 @@ class NintendoWiiUMediaPlayer(WiiUEntity, MediaPlayerEntity):
         """Turn off the Wii U console."""
         await self.coordinator.wii.async_shutdown()
         self.coordinator.is_on = False
+        self.schedule_update_ha_state(force_refresh=True)

--- a/custom_components/nintendo_wiiu_ristretto/sensor.py
+++ b/custom_components/nintendo_wiiu_ristretto/sensor.py
@@ -20,6 +20,7 @@ class WiiUSensorEntityDescription(SensorEntityDescription):
 
     value_fn: Callable[[WiiUEntity], None] = lambda: None
 
+
 ENTITY_DESCRIPTIONS: list[WiiUSensorEntityDescription] = [
     WiiUSensorEntityDescription(
         key="gamepad_battery",
@@ -28,9 +29,10 @@ ENTITY_DESCRIPTIONS: list[WiiUSensorEntityDescription] = [
         name="Gamepad Battery",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.BATTERY,
-        value_fn=lambda entity: entity.coordinator.gamepad_battery
+        value_fn=lambda entity: entity.coordinator.gamepad_battery,
     )
 ]
+
 
 async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
     """Set up the button platform."""
@@ -38,10 +40,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
     if not isinstance(coordinator, WiiUCoordinator):
         return
     async_add_entities(
-        [GenericWiiUSensor(coordinator=coordinator, description=description) 
-         for description in ENTITY_DESCRIPTIONS
+        [
+            GenericWiiUSensor(coordinator=coordinator, description=description)
+            for description in ENTITY_DESCRIPTIONS
         ]
     )
+
 
 class GenericWiiUSensor(WiiUEntity, RestoreSensor):
     """Generic sensor for Wii U using a restore sensor."""

--- a/custom_components/nintendo_wiiu_ristretto/sensor.py
+++ b/custom_components/nintendo_wiiu_ristretto/sensor.py
@@ -30,6 +30,7 @@ ENTITY_DESCRIPTIONS: list[WiiUSensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.BATTERY,
         value_fn=lambda entity: entity.coordinator.gamepad_battery,
+        suggested_display_precision=0
     )
 ]
 

--- a/custom_components/nintendo_wiiu_ristretto/sensor.py
+++ b/custom_components/nintendo_wiiu_ristretto/sensor.py
@@ -1,0 +1,60 @@
+"""Sensors for Wii U."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from homeassistant.components.sensor import (
+    RestoreSensor,
+    SensorDeviceClass,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+
+from .coordinator import WiiUCoordinator
+from .entity import WiiUEntity
+
+
+@dataclass(frozen=True, kw_only=True)
+class WiiUSensorEntityDescription(SensorEntityDescription):
+    """Class describing Wii U button entities."""
+
+    value_fn: Callable[[WiiUEntity], None] = lambda: None
+
+ENTITY_DESCRIPTIONS: list[WiiUSensorEntityDescription] = [
+    WiiUSensorEntityDescription(
+        key="gamepad_battery",
+        native_unit_of_measurement="%",
+        icon="mdi:battery",
+        name="Gamepad Battery",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.BATTERY,
+        value_fn=lambda entity: entity.coordinator.gamepad_battery
+    )
+]
+
+async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
+    """Set up the button platform."""
+    coordinator = config_entry.runtime_data
+    if not isinstance(coordinator, WiiUCoordinator):
+        return
+    async_add_entities(
+        [GenericWiiUSensor(coordinator=coordinator, description=description) 
+         for description in ENTITY_DESCRIPTIONS
+        ]
+    )
+
+class GenericWiiUSensor(WiiUEntity, RestoreSensor):
+    """Generic sensor for Wii U using a restore sensor."""
+
+    def __init__(
+        self, coordinator: WiiUCoordinator, description: WiiUSensorEntityDescription
+    ) -> None:
+        """Initialize the button."""
+        super().__init__(coordinator=coordinator)
+        self.coordinator = coordinator
+        self.entity_description: WiiUSensorEntityDescription = description
+
+    @property
+    def native_value(self) -> int:
+        """Return native value of the sensor."""
+        return self.entity_description.value_fn(self)

--- a/custom_components/nintendo_wiiu_ristretto/translations/en.json
+++ b/custom_components/nintendo_wiiu_ristretto/translations/en.json
@@ -6,7 +6,9 @@
                 "data": {
                     "ip_address": "IP Address",
                     "port": "Ristretto Port",
-                    "name": "Device Name"
+                    "name": "Device Name",
+                    "scan_interval": "Update Interval",
+                    "timeout": "Timeout"
                 }
             }
         },


### PR DESCRIPTION
# Summary

Introduce support for Wii U gamepad battery as a sensor, enhance asynchronous operations throughout the code, and add a timeout configuration option. Remove unnecessary proxy functions and streamline the coordinator's session management.

# Details

A fairly large PR again, sorry!

- Move all operations to new async functions provided by module
- Add sensor platform to output gamepad battery level ~although I could use your advice here, what does this actually represent? A full battery (according to the state on the consoles screen) outputs the value "6" for me. Does the Wii only output numbers 0 to 6? I noticed that when charging this is `0`~
- Add some specific definitions to `WiiUButtonEntityDescription` - this isn't actually needed, but VSCode is going insane on my machine about that for some reason.
- Restart button uses the direct function in the WiiU class rather than the proxy in the coordinator
- Tidy `async_setup_entry` logic in platforms where an `ENTITY_DESCRIPTION` is used, don't actually need a full for loop here since we aren't doing any extra logic on the entity descriptions
- Add `available` property to `GenericWiiUButton` class so the entity goes unavailable when the console is off (prevents sending calls to the button when the console is in a state it can't receive them)
- Add `CONF_TIMEOUT` option to config flow
- Move default config option values to specific `const.py` for maintainability (at the moment both is set to 10s, but might wanna change these depending on what the console can handle)
- Coordinator collects gamepad battery on each update interval
- Remove loop in `_get_source_list` as this is not required
- Use the Home Assistant helper method `async_create_clientsession` to allow HA to create and manage an async web session for us (that way we don't need to worry about closing the session down)
- Specify `TimeoutError, ClientOSError, ConnectionError` as unavailable errors, this way the integration can correctly log errors if something else is wrong (like `ValueError` etc.)
- Media Player: remove need for proxy methods in both `async_select_source` and `async_turn_off` functions
- Remove _attr_unique_id definition, actually I've kinda reverted my change in a previous PR as when you add more than one entity to the same platform, it creates a problem. Instead it now uses the serial and entity key (or just serial for media_player)
- Add Launch vWii button
- Set `suggested_display_precision` for gamepad battery level to `0`
- Disregard `ClientOSError` exceptions - I found that this creates a "bounce" to the on/off state when switching apps.

QOL:

- Update release workflow to use correct integration path
- Update lint workflow to use Python 3.13 as 3.12 is not compatible with HA 2025.2.0+